### PR TITLE
Use port 3000

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,4 +3,4 @@ services:
     build:
       dockerfile: docker/Dockerfile
     ports:
-      - "8081:8081"
+      - "3000:3000"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y \
 RUN playwright install
 
 # Expose the application port
-EXPOSE 8081
+EXPOSE 3000
 
 # Define the command to run the application
-CMD ["uvicorn", "app.main:app", "--host=0.0.0.0", "--port=8081", "--reload"]
+CMD ["uvicorn", "app.main:app", "--host=0.0.0.0", "--port=3000", "--reload"]


### PR DESCRIPTION
This is the port indicated in the test description.

<img width="597" alt="Screenshot 2025-05-17 at 11 15 24" src="https://github.com/user-attachments/assets/fc73a9ad-14c0-4259-a9bc-0dfc6ac7278a" />

```bash
app-1  | INFO:     Will watch for changes in these directories: ['/app']
app-1  | INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
app-1  | INFO:     Started reloader process [1] using StatReload
app-1  | INFO:     Started server process [8]
app-1  | INFO:     Waiting for application startup.
app-1  | INFO:     Application startup complete.
```